### PR TITLE
usage: allow specifying username field in a config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,12 @@ the field choice dialogue when there is only a password in the file.
 The `-t | --type` flag tells `wofi-pass` to type the choice instead of copying 
 to clipboard. This also enables the autotype choice which types 
 `username :tab password`.
+
+## Configuration
+wofi-pass may read its configuration values from different locations in the following order:
+* `$XDG_CONFIG_HOME/wofi-pass/config` (defaulting to `$HOME/.config/wofi-pass/config`)
+* `/etc/wofi-pass.conf`
+
+wofi-pass only loads the first existing file. In case no config file exists, wofi-pass uses its internal default values.
+
+For an example configuration please take a look at the included `config.example` file.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ to clipboard. This also enables the autotype choice which types
 ## Configuration
 
 wofi-pass can read its configuration values from various locations in the following order:
+* `WOFI_PASS_CONFIG` (environment variable)
 * `$XDG_CONFIG_HOME/wofi-pass/config`
 * `/etc/wofi-pass.conf`
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ to clipboard. This also enables the autotype choice which types
 `username :tab password`.
 
 ## Configuration
-wofi-pass may read its configuration values from different locations in the following order:
-* `$XDG_CONFIG_HOME/wofi-pass/config` (defaulting to `$HOME/.config/wofi-pass/config`)
+
+wofi-pass can read its configuration values from various locations in the following order:
+* `$XDG_CONFIG_HOME/wofi-pass/config`
 * `/etc/wofi-pass.conf`
 
-wofi-pass only loads the first existing file. In case no config file exists, wofi-pass uses its internal default values.
+If `XDG_CONFIG_HOME` environment variable is not set, `${HOME}/.config` will be used.
 
-For an example configuration please take a look at the included `config.example` file.
+wofi-pass loads only the first existing file. If no configuration file exists, wofi-pass uses its internal defaults.
+
+An example configuration file can be found in the supplied `config.example` file.

--- a/config.example
+++ b/config.example
@@ -1,0 +1,4 @@
+CMD_COPY="wl-copy"
+CMD_TYPE="wtype -"
+
+USERNAME_field="username"

--- a/config.example
+++ b/config.example
@@ -1,4 +1,4 @@
 CMD_COPY="wl-copy"
 CMD_TYPE="wtype -"
 
-USERNAME_field="username"
+PASS_FIELD_USERNAME="username"

--- a/wofi-pass
+++ b/wofi-pass
@@ -107,12 +107,13 @@ get_config_file () {
     local config_base_dir="${XDG_CONFIG_HOME:-"${HOME}/.config"}"
     readonly config_base_dir
 
-    config_files=("${config_base_dir}/wofi-pass/config"
+    config_files=("${WOFI_PASS_CONFIG:-""}"
+                  "${config_base_dir}/wofi-pass/config"
                   "/etc/wofi-pass.conf")
 
     # return the first config file with a valid path
     for config in "${config_files[@]}"; do
-        if [[ -f "${config}" ]]; then
+        if [[ -n "${config}" && -f "${config}" ]]; then
             printf "%s" "${config}"
             return
         fi

--- a/wofi-pass
+++ b/wofi-pass
@@ -16,7 +16,7 @@ CMD_COPY="wl-copy"
 CMD_TYPE="wtype -"
 
 # We expect to find these fields in pass(1)'s output
-USERNAME_field='username'
+PASS_FIELD_USERNAME='username'
 
 function _wofi() {
     wofi "$@"
@@ -40,13 +40,13 @@ function parse_fields() {
 "
     if [ "${FLAG_FILEASUSER}" -eq 1 ]; then
         has_username=1
-        line="$USERNAME_field"
+        line="${PASS_FIELD_USERNAME}"
         field_list="${field_list}${line}
 "
     fi
 
     for line in ${fields}; do
-        if [ "${line}" = "$USERNAME_field" ]; then
+        if [ "${line}" = "${PASS_FIELD_USERNAME}" ]; then
             has_username=1
             field_list="${field_list}${line}
 "
@@ -78,7 +78,7 @@ function pass_get() {
         pass show "${password}" | { IFS= read -r pass; printf %s "${pass}"; }
     elif [ "${1}" = "OTP" ]; then
         pass otp "${password}" | tail -n1 | { IFS= read -r pass; printf %s "${pass}"; }
-    elif [ "${FLAG_FILEASUSER}" -eq 1 ] && [ "${1}" = "$USERNAME_field" ]; then
+    elif [ "${FLAG_FILEASUSER}" -eq 1 ] && [ "${1}" = "${PASS_FIELD_USERNAME}" ]; then
         printf %s "${passname}"
     else
         pass_field "${@}"
@@ -104,24 +104,28 @@ EOF
 }
 
 get_config_file () {
-    [ ! "$XDG_CONFIG_HOME" ] && export XDG_CONFIG_HOME="$HOME/.config"
-    configs=("$XDG_CONFIG_HOME/wofi-pass/config"
-             "/etc/wofi-pass.conf")
+    local config_base_dir="${XDG_CONFIG_HOME:-"${HOME}/.config"}"
+    readonly config_base_dir
+
+    config_files=("${config_base_dir}/wofi-pass/config"
+                  "/etc/wofi-pass.conf")
 
     # return the first config file with a valid path
-    for config in "${configs[@]}"; do
-        # '-n' is needed in case WOFI_PASS_CONFIG is not set
-        if [[ -n "${config}" && -f "${config}" ]]; then
-            printf "%s" "$config"
+    for config in "${config_files[@]}"; do
+        if [[ -f "${config}" ]]; then
+            printf "%s" "${config}"
             return
         fi
     done
 }
 
-function main() {
-    # load config file
+load_config_file () {
     config_file="$(get_config_file)"
-    [[ -n "$config_file" ]] && source "$config_file"
+    [[ -n "${config_file}" ]] && source "${config_file}"
+}
+
+function main() {
+    load_config_file
 
     OPTS="$(getopt --options ac::fhst:: --longoptions autotype,copy::,fileisuser,help,squash,type:: -n 'wofi-pass' -- "${@}")"
     eval set -- "${OPTS}"
@@ -199,7 +203,7 @@ function main() {
         if [ "${FLAG_FILEASUSER}" -eq 1 ]; then
             username="${passname}"
         else
-            username=$(pass_get "$USERNAME_field")
+            username=$(pass_get "${PASS_FIELD_USERNAME}")
         fi
         password=$(pass_get "password")
 

--- a/wofi-pass
+++ b/wofi-pass
@@ -15,6 +15,9 @@ FLAG_HELP=0
 CMD_COPY="wl-copy"
 CMD_TYPE="wtype -"
 
+# We expect to find these fields in pass(1)'s output
+USERNAME_field='username'
+
 function _wofi() {
     wofi "$@"
 }
@@ -35,16 +38,15 @@ function parse_fields() {
     local -r fields="$(pass show "${password}" | tail -n +2 | cut -d: -f1 -s)"
     local field_list="password
 "
-
     if [ "${FLAG_FILEASUSER}" -eq 1 ]; then
         has_username=1
-        line="username"
+        line="$USERNAME_field"
         field_list="${field_list}${line}
 "
     fi
 
     for line in ${fields}; do
-        if [ "${line}" = "username" ]; then
+        if [ "${line}" = "$USERNAME_field" ]; then
             has_username=1
             field_list="${field_list}${line}
 "
@@ -76,7 +78,7 @@ function pass_get() {
         pass show "${password}" | { IFS= read -r pass; printf %s "${pass}"; }
     elif [ "${1}" = "OTP" ]; then
         pass otp "${password}" | tail -n1 | { IFS= read -r pass; printf %s "${pass}"; }
-    elif [ "${FLAG_FILEASUSER}" -eq 1 ] && [ "${1}" = "username" ]; then
+    elif [ "${FLAG_FILEASUSER}" -eq 1 ] && [ "${1}" = "$USERNAME_field" ]; then
         printf %s "${passname}"
     else
         pass_field "${@}"
@@ -101,7 +103,26 @@ function usage() {
 EOF
 }
 
+get_config_file () {
+    [ ! "$XDG_CONFIG_HOME" ] && export XDG_CONFIG_HOME="$HOME/.config"
+    configs=("$XDG_CONFIG_HOME/wofi-pass/config"
+             "/etc/wofi-pass.conf")
+
+    # return the first config file with a valid path
+    for config in "${configs[@]}"; do
+        # '-n' is needed in case WOFI_PASS_CONFIG is not set
+        if [[ -n "${config}" && -f "${config}" ]]; then
+            printf "%s" "$config"
+            return
+        fi
+    done
+}
+
 function main() {
+    # load config file
+    config_file="$(get_config_file)"
+    [[ -n "$config_file" ]] && source "$config_file"
+
     OPTS="$(getopt --options ac::fhst:: --longoptions autotype,copy::,fileisuser,help,squash,type:: -n 'wofi-pass' -- "${@}")"
     eval set -- "${OPTS}"
     while true; do
@@ -178,7 +199,7 @@ function main() {
         if [ "${FLAG_FILEASUSER}" -eq 1 ]; then
             username="${passname}"
         else
-            username=$(pass_get "username")
+            username=$(pass_get "$USERNAME_field")
         fi
         password=$(pass_get "password")
 


### PR DESCRIPTION
## Case
A lot of sites have you make a user name but use email address for authentication (usually allowing either email or username to be used but not always).
So I keep my passwords formatted the following way:
```
Th3Gr3at3stPassw0rd    
user: john@example.com
username: JohnDoe     
pin: 1234    
otpauth://totp/example?secret=ABCDCBABCDCBABCD  
```
Where `user:` field is what is used for authentication, and `username:` one is just a note for myself.

rofi-pass (which I used as a source for my changes) allowed to specify the field used for auto-typing in a config file which I really miss with wofi-pass.

## Changes
* adding an option to to specify `USERNAME_field` similar to `rofi-pass` in a config file.
* as a consequence you should also be able to customize `CMD_COPY` and `CMD_TYPE` the same way
* config file will be picked up from `$XDG_CONFIG_HOME/wofi-pass/config` or `/etc/wofi-pass.conf` to match rofi
* if `$XDG_CONFIG_HOME` is not set for the user default to `$HOME/.config`

## Caveats
* I have left the default as `username` as not to break anyone's setup.
* `set -u` at the beginning of the script prevents me from allowing to use `$ROFI_PASS_CONFIG` env variable to set a custom path for the config similar to what `rofi-pass` does. I didn't want to remove the flag as I don't know if anything depends on it and I don't particularly care about changing the default path myself.
* I have never worked with man pages before so I am not sure how to update them with this change - apologies.