### PR TITLE
autotype: add new keyword :username

### DIFF
--- a/man/wofi-pass.1
+++ b/man/wofi-pass.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "WOFI\-PASS" "1" "October 2023" ""
+.TH "WOFI\-PASS" "1" "November 2023" ""
 .SH "NAME"
 \fBwofi\-pass\fR \- pass support for wofi
 .SH "SYNOPSIS"
@@ -102,6 +102,9 @@ Output the One Time Password
 .TP
 \fB:password\fR
 Output the password
+.TP
+\fB:username\fR
+Output the username field, defined by \fBPASS_FIELD_USERNAME\fR
 .TP
 \fB:path\fR
 Output the filename of selected \fB:pass\fR entry

--- a/man/wofi-pass.1.ronn
+++ b/man/wofi-pass.1.ronn
@@ -117,6 +117,9 @@ Output the One Time Password
 * `:password`:
 Output the password
 
+* `:username`:
+Output the username field, defined by `PASS_FIELD_USERNAME`
+
 * `:path`:
 Output the filename of selected `:pass` entry
 

--- a/tests/test_output_autotype
+++ b/tests/test_output_autotype
@@ -13,6 +13,7 @@ fake_pass_get() {
     values[password]="paSSw0rd"
     values[username]="user@e-mail.com"
 	values[user]="other@user-name.com"
+    values[login]="userlogin"
     values[url]="https://example.com"
     values[autotype]=""
     printf "%s" "${values[${field}]}"
@@ -42,6 +43,10 @@ test_output_autotype_default() {
     FLAG_TYPE=1
 	output="$(output_autotype "/dir/dir1/passname" "fake_cmd_output")"
 	assert_equals "user@e-mail.com<Tab>paSSw0rd" "${output}" "output autotype: unexpected output"
+
+    PASS_FIELD_USERNAME="login"
+	output="$(output_autotype "/dir/dir1/passname" "fake_cmd_output")"
+	assert_equals "userlogin<Tab>paSSw0rd" "${output}" "output autotype: unexpected output"
 }
 
 test_output_autotype_single_keyword() {
@@ -59,6 +64,7 @@ test_output_autotype_single_keyword() {
     outputs[password]="paSSw0rd"
     outputs[path]="passname"
 	outputs[username]="user@e-mail.com"
+    outputs[login]="userlogin"
 	outputs[url]="https://example.com"
 
     type_outputs[tab]="<Tab>"
@@ -69,12 +75,13 @@ test_output_autotype_single_keyword() {
     type_outputs[password]="paSSw0rd"
     type_outputs[path]="passname"
 	type_outputs[username]="user@e-mail.com"
+    type_outputs[login]="userlogin"
 	type_outputs[url]="https://example.com"
 
-    keywords=("tab" "space" "enter" "delay" "otp" "password" "path" "username" "url")
+    keywords=("tab" "space" "enter" "delay" "otp" "password" "path" "username" "login" "url")
     for keyword in "${keywords[@]}"; do
         FLAG_TYPE=0
-        if [ "${keyword}" = "username" ] || [ "${keyword}" = "url" ]; then
+        if [ "${keyword}" = "login" ] || [ "${keyword}" = "url" ]; then
             WOFI_PASS_AUTOTYPE="${keyword}"
         else
             WOFI_PASS_AUTOTYPE=":${keyword}"
@@ -86,6 +93,19 @@ test_output_autotype_single_keyword() {
         output="$(output_autotype "/dir/dir1/passname" "fake_cmd_output")"
         assert_equals "${type_outputs[${keyword}]}" "${output}" "output autotype: unexpected output"
     done
+}
+
+test_output_autotype_customize_username() {
+    fake pass_get fake_pass_get
+    fake press_key fake_press_key
+
+    WOFI_PASS_AUTOTYPE=":username"
+    local output="$(output_autotype "/dir/dir1/passname" "fake_cmd_output")"
+    assert_equals "user@e-mail.com" "${output}" "output autotype: unexpected output for default username"
+
+    PASS_FIELD_USERNAME="login"
+    output="$(output_autotype "/dir/dir1/passname" "fake_cmd_output")"
+    assert_equals "userlogin" "${output}" "output autotype: unexpected output for customized username"
 }
 
 setup_suite() {

--- a/wofi-pass
+++ b/wofi-pass
@@ -18,7 +18,7 @@ CMD_TYPE="${CMD_TYPE:-"wtype -"}"
 # We expect to find these fields in pass(1)'s output
 PASS_FIELD_USERNAME="${PASS_FIELD_USERNAME:-"username"}"
 
-WOFI_PASS_AUTOTYPE="${WOFI_PASS_AUTOTYPE:-"${PASS_FIELD_USERNAME} :tab :password"}"
+WOFI_PASS_AUTOTYPE="${WOFI_PASS_AUTOTYPE:-":username :tab :password"}"
 WOFI_PASS_DELAY=${WOFI_PASS_DELAY:-2}
 WOFI_PASS_AUTO_ENTER="${WOFI_PASS_AUTO_ENTER:-"false"}"
 
@@ -248,6 +248,7 @@ function output_autotype() {
             ":delay") [ ${FLAG_TYPE} -eq 1 ] && sleep "${WOFI_PASS_DELAY}";;
             ":otp") printf "%s" "$(generate_otp "${passname}")" | ${cmd_output};;
             ":password") printf "%s" "${password}" | ${cmd_output};;
+            ":username") printf "%s" "$(pass_get "${passname}" "${PASS_FIELD_USERNAME}")" | ${cmd_output};;
             ":path") printf "%s" "${passname##*/}" | ${cmd_output};;
             *) printf "%s" "$(pass_get "${passname}" "${word}")" | ${cmd_output}
         esac

--- a/wofi-pass.conf
+++ b/wofi-pass.conf
@@ -15,7 +15,7 @@
 #PASSWORD_STORE_DIR="${HOME}/.password-store"
 
 # default autotype format
-#WOFI_PASS_AUTOTYPE="username :tab :password"
+#WOFI_PASS_AUTOTYPE=":username :tab :password"
 
 # autotype delay time in seconds
 #WOFI_PASS_DELAY=2


### PR DESCRIPTION
This PR add new keyword for autotype.
The :username allows using the customized username field defined by PASS_FIELD_USERNAME variable.